### PR TITLE
[Python] Correcting folder when on Omega2+

### DIFF
--- a/Omega2/Documentation/Doing-Stuff/Installing-Software/Installing-and-Using-Python.md
+++ b/Omega2/Documentation/Doing-Stuff/Installing-Software/Installing-and-Using-Python.md
@@ -124,6 +124,8 @@ import os, datetime, time
 
 
 ## Set the Omega LED trigger to "timer" so that it blinks
+## Note: If you're using Omega2+, use the following line instead: 
+##       with open("/sys/class/leds/omega2p:amber:system/trigger", "w") as trigger:
 with open("/sys/class/leds/onion:amber:system/trigger", "w") as trigger:
           trigger.write("timer")
 
@@ -146,6 +148,8 @@ else:
 time.sleep(5)
 
 # Set the Omega LED back to being always on
+## Note: If you're using Omega2+, use the following line instead: 
+##       with open("/sys/class/leds/omega2p:amber:system/trigger", "w") as trigger:
 with open("/sys/class/leds/onion:amber:system/trigger", "w") as trigger:
         trigger.write("default-on")
 


### PR DESCRIPTION
Added note to use "/sys/class/leds/omega2p" instead of "/sys/class/leds/onion" when using Omega2+ hardware.