### PR TITLE
Fix the macOS keyboard shortcut to paste into a terminal

### DIFF
--- a/Omega2/Documentation/Get-Started/Using-the-Console/Developing-using-the-console.md
+++ b/Omega2/Documentation/Get-Started/Using-the-Console/Developing-using-the-console.md
@@ -51,7 +51,7 @@ To tell the kernel that we are going to use the Morse code module, set the LED t
 echo morse > /sys/class/leds/onion\:amber\:system/trigger
 ```
 
-> To paste into the Terminal app, use `ctrl+shift+v` or `cmd+shift+v` on a MAC
+> To paste into the Terminal app, use `ctrl+shift+v` or `cmd+v` on a MAC
 
 
 You can verify that it worked by using `cat` to look at the virtual file:


### PR DESCRIPTION
As OS X has `cmd` and `ctrl` keys, normally there is not need to use `shift` as modifier. This means that copy would be `cmd+c` and interrupt proccess `ctrl+c`.