### PR TITLE
Add link to download Apple Bonjour Service

### DIFF
--- a/Omega2/Documentation/Get-Started/First-Time-Components/First-Time-Component-01-computer-config.md
+++ b/Omega2/Documentation/Get-Started/First-Time-Components/First-Time-Component-01-computer-config.md
@@ -2,6 +2,6 @@
 
 Your computer may need some additional programs to access the Omega through a browser:
 
-* If you are using Windows, install Apple's Bonjour Service
+* If you are using Windows, install Apple's [Bonjour Service](https://support.apple.com/kb/DL999)
 * If you are using OS X, you're all set to go
 * If you are using Linux, the Zeroconf services should already be installed and you will be good to go


### PR DESCRIPTION
To make it a little nicer for newer users who may not know where to find Bonjour Services, or what it is, add a direct link to a KB article that provides download links for windows users.