### PR TITLE
Fixes broken power supply image

### DIFF
--- a/Omega2/Kit-Guides/shared/circuit-components/power-supply.md
+++ b/Omega2/Kit-Guides/shared/circuit-components/power-supply.md
@@ -6,5 +6,5 @@ The power supply is the driving force in any circuit we build.
 
 A power supply does as it is named - provides the power for our circuits to run. If we model electricity as a waterfall, the current is the amount of water flowing through, and the voltage is the height of the falls. The power supply is the source of both flow and height. The power supply is a 'single' terminal in most diagrams, however its other terminal is actually the ground terminal - just like waterfalls need the ground to reference how high they are.
 
-![A typical USB power supply](https://raw.githubusercontent.com/OnionIoT/Onion-Docs/master/Omega2/Kit-Guides/img/power-supply-photo.jpg)
+![A typical USB power supply](https://raw.githubusercontent.com/OnionIoT/Onion-Docs/master/Omega2/Kit-Guides/img/power-supply-photo.JPG)
 


### PR DESCRIPTION
The URL for the power supply image was incorrect — jpg vs. JPG.