### PR TITLE
Fixed the name of the oled temperature repo in a couple places.

### DIFF
--- a/Omega2/Projects/oled/temperature-monitor.md
+++ b/Omega2/Projects/oled/temperature-monitor.md
@@ -75,7 +75,7 @@ The code for this project is all done and can be found in Onion's [`temperature-
 
 ```
 cd /root
-git clone https://github.com/OnionIoT/oled-temperature-monitor.git
+git clone https://github.com/OnionIoT/temperature-monitor.git
 ```
 
 #### 4. Setup Ubidots
@@ -183,7 +183,7 @@ Enter `crontab -e` to add a task to the `cron` daemon, it will open a file in vi
 #
 ```
 
-> This assumes that your project code is located in `/root/oled-temperature-monitor`
+> This assumes that your project code is located in `/root/temperature-monitor`
 
 Now, we'll restart `cron`:
 


### PR DESCRIPTION
Fellow Onioneers,

The name of the oled temperature repo is incorrect in a couple of places on the oled project page.
This pull request ought to fix that for you.

Still new to git and github, so hopefully I didn't mess anything up. Let me know if I did.
Thanks
