### PR TITLE
Update Boot-from-External-Storage.md

### DIFF
--- a/Omega2/Documentation/Doing-Stuff/Advanced/Boot-from-External-Storage.md
+++ b/Omega2/Documentation/Doing-Stuff/Advanced/Boot-from-External-Storage.md
@@ -220,28 +220,25 @@ Then edit the `/etc/config/fstab` file to enable auto-mounting the `/overlay` di
 vi /etc/config/fstab
 ```
 
-Look for the line
+Look for the block
 
 ```
-option  target  '/mnt/<device name>'
+config 'mount'
+	option	target	'/mnt/<device name>'
+	option	uuid	'<long ID>'
+	option	enabled	'0'
 ```
 
 and change it to:
 
 ```
-option target '/overlay'
-```
-
-Then, look for the line:
-
-```
-option  enabled '0'
-```
-
-and change it to
-
-```
-option  enabled '1'
+config 'mount'
+    option target        '/'
+    option device        '/dev/<device name>'
+    option fstype        'ext4'
+    option options       'rw,sync'
+    option enabled       '1'
+    option enabled_fsck  '0'
 ```
 
 >If your USB device uses one of the drivers from `kmod-usb-storage-extras`, you will need to run the following: `ln -s  /etc/modules.d/usb-storage-extras /etc/modules-boot.d/usb-storage-extras`


### PR DESCRIPTION
I had some problems booting my Omega 2+ with an external storage (micro SD card).

I followed the instructions in https://docs.onion.io/omega2-docs/boot-from-external-storage.html#boot-from-external-storage

and found out it didn't work. I searched in the community and found here the answer: https://community.onion.io/topic/2669/running-onion-omega-2-from-the-usb-external-storage-device/5

That worked for me! I hope you consider the changes in the documentation