### PR TITLE
Generating-PWM-Signals.md - Expand text for go-pwm-example to include…

### DIFF
--- a/Omega2/Documentation/Doing-Stuff/Generating-PWM-Signals.md
+++ b/Omega2/Documentation/Doing-Stuff/Generating-PWM-Signals.md
@@ -220,4 +220,4 @@ You should now be able to observe the 1kHz signal with 75% duty cycle on the pwm
 
 #### Golang example
 
-Visit [chmorgan/go-pwm-example](https://github.com/chmorgan/go-pwm-example) for an example of controlling the hardware PWM modules from your own application. Through the use of golang, and its support of various architectures, it is possible to build and load this example onto your Omega2 module in a matter of minutes.
+Visit [https://github.com/chmorgan/go-pwm-example](https://github.com/chmorgan/go-pwm-example) for an example of controlling the hardware PWM modules from your own application. Through the use of golang, and its support of various architectures, it is possible to build and load this example onto your Omega2 module in a matter of minutes.


### PR DESCRIPTION
… the full url so the reader knows it is on github and for better usage when converted to pdf.

The app note here, https://onion.io/2bt-mar19-2019/, doesn't appear to have a clickable url for the repository. Without the full url users may not be able to find the example project so expanded the url in this document assuming the app note was generated from this content directly.

It should be possible to have that link work, not sure why that link isn't but the above link to syses is...

Anyway, it still might be good to have the full url so its possible to tell the link is to GitHub.